### PR TITLE
Spring 2016 rules updates

### DIFF
--- a/presentation/presentation.tex
+++ b/presentation/presentation.tex
@@ -76,7 +76,7 @@
 % - Keep it simple, no one is interested in your street address.
 
 \date % (optional, should be abbreviation of conference name)
-{Fall 2015}
+{Spring 2016}
 % - Either use conference name or its abbreviation.
 % - Not really informative to the audience, more for people (including
 %   yourself) who are reading the slides online

--- a/presentation/presentation.tex
+++ b/presentation/presentation.tex
@@ -458,7 +458,7 @@
           & \R{Red} & \G{Green} & \B{Blue} \\
   \hline
   \hline
-     Wand & \pair{\R{Vengeance}}{"toast"}
+     Wand & \pair{\R{Vengeance}}{``toast''}
           & \pair{\G{Stun}}{stun target}
           & \pair{\B{Dispel}}{remove magic} \\
   \hline
@@ -681,7 +681,7 @@
           & \R{Red} & \G{Green} & \B{Blue} \\
   \hline
   \hline
-     Wand & \pair{\R{Vengeance}}{"toast"}
+     Wand & \pair{\R{Vengeance}}{``toast''}
           & \pair{\G{Stun}}{stun target}
           & \pair{\B{Dispel}}{remove magic} \\
   \hline
@@ -950,7 +950,7 @@
 
   \begin{itemize}
   \item \B{Blue Belt}
-  \item Captor hands belt to captive and says "I'LL BE BACH!!"
+  \item Captor hands belt to captive and says ``I'LL BE BACH!!''
   \item Captive sits down and is a captive of the belt
     \subitem{(for one minute)}
     \subitem{If dispelled, captive goes free}
@@ -1104,7 +1104,7 @@
   \begin{itemize}
   \item \B{Blue potion}
   \item Only useable by captor
-  \item Keyword: ``Obey"
+  \item Keyword: ``Obey''
   \item Captive takes potion, goes to jail alone
   \item Captor stunned for \textbf{10 seconds}
   \end{itemize}
@@ -1144,7 +1144,7 @@
 \begin{frame}{Glyph of Alarm}{\sep Stuff}
   %IMAGE
   \begin{itemize}
-  \item Yell "Alarm" or be loud
+  \item Yell ``Alarm'' or be loud
   \begin{itemize}
     \item For one minute
     \item Or until entering neutral space
@@ -1210,7 +1210,7 @@
           & \R{Red} & \G{Green} & \B{Blue} \\
   \hline
   \hline
-     Wand & \pair{\R{Vengeance}}{"toast"}
+     Wand & \pair{\R{Vengeance}}{``toast''}
           & \pair{\G{Stun}}{stun target}
           & \pair{\B{Dispel}}{remove magic} \\
   \hline
@@ -1282,7 +1282,7 @@
           & \R{Red} & \G{Green} & \B{Blue} \\
   \hline
   \hline
-     Wand & \pair{\R{Vengeance}}{"toast"}
+     Wand & \pair{\R{Vengeance}}{``toast''}
           & \pair{\G{Stun}}{stun target}
           & \pair{\B{Dispel}}{remove magic} \\
   \hline

--- a/presentation/presentation.tex
+++ b/presentation/presentation.tex
@@ -987,7 +987,7 @@
   \item Captor has one minute to get another captive and return to original captive
     \subitem{If successful, they escort both captives to jail \textbf{with belt}}
     \subitem{Belt can still be dispelled, freeing the second captive}
-    \subitem{If the timer expires, original captive goes free}
+    \subitem{If one minute elapses, original captive goes free}
   \end{itemize}
 
    \begin{tikzpicture}[x=0.5cm, y=0.5cm]

--- a/rules/full.txt
+++ b/rules/full.txt
@@ -170,8 +170,8 @@ re-enter their home territories.
 * A player in a normal state not carrying a flag may touch a prisoner
 in another team's jail. As long as freeing the prisoner does not break a
 chain leading back to the jail, the prisoner is freed. Both players are
-ethereal and must return to their home territories by the most direct
-route; they need not remain together.
+ethereal (:and must return to their home territory as after a jailbreak (see [[jailbreak]]):);
+they need not remain together.
 * The jailer has a supply of Truth Serum, which they may use by
 poking a prisoner in the shoulder with a pinky finger. The prisoner
 then becomes an interrogation victim.

--- a/rules/full.txt
+++ b/rules/full.txt
@@ -418,11 +418,9 @@ singing along.
 * This belt does not function in elevators.
 
 !! Arnold's Belt of Double Termination
-:* Arnold's Belt of Double Termination is blue. It shall have a timer
-on it.
+:* Arnold's Belt of Double Termination is blue.
 :* Only captors who have exactly one captive may use Arnold's Belt. To activate this belt the wearer
-must hand the belt to their captive, use the key phrase "I'LL BE BACH!!" and
-start the timer.
+must hand the belt to their captive, use the key phrase "I'LL BE BACH!!".
 :* A captive who is handed this belt by their captor becomes a captive of the
 belt. They must sit down and place the belt visibly in front of them. A player
 affected by Arnold's Belt is still a captive. They may not be stunned,

--- a/rules/generate.rb
+++ b/rules/generate.rb
@@ -348,13 +348,13 @@ else
    <br>
    <i>Revised 9/21/2014 by mwoolfor, jlareau, sguertin, egarbade, afrieder, ssharera, cmorey, bwachowi, jnemes...</i>
    <br>
-   <i>Revised 11/4/2015, by briedel, egarbade, tparenti, mwoolfor, cmorey, eeb, jlareau, jpdoyle, sctoor</i>
+   <i>Revised 11/4/2015, 2/8/2016, by briedel, egarbade, tparenti, mwoolfor, cmorey, eeb, jlareau, jpdoyle, sctoor</i>
    <br>
    <i>Classic rules may be found <a href="ctfws_old.php">here</a></i></center>
 
    <br>
    <br>
-<h3>These are the <span class="change">preliminary</span> rules for the Fall 2015 game of Capture the Flag with Stuff.</h3>
+<h3>These are the <span class="change">preliminary</span> rules for the Spring 2016 game of Capture the Flag with Stuff.</h3>
    <br>
 <?php
 if (!$view_print)

--- a/rules/useful.txt
+++ b/rules/useful.txt
@@ -151,7 +151,7 @@ they are ethereal.<br>
 If you touch a prisoner in the other team's jail, and freeing them does
 not break the chain leading back to the Glyph of Jail, they are freed. You
 both become ethereal, and must return to your home territory as on a
-jailbreak (etherial, with jazz hands).<br>
+jailbreak (ethereal, with jazz hands).<br>
 The jailer (if one exists) also has a supply of Truth Serum. He may
 poke a prisoner in the shoulder with a pinky, making the prisoner an
 interrogation victim, and freeing any previous victim. The victim is
@@ -164,7 +164,7 @@ The questioning is finished when the victim answers the sixth question,
 if the jailer decides they are done, if the victim is freed, at jailbreak,
 if there is no jailer, or if the jailer leaves line of sight of the
 victim. At this point, the victim becomes ethereal and must return to
-their home territory as after a jailbreak (etherial, with jaz hands).<br>
+their home territory as after a jailbreak (ethereal, with jazz hands).<br>
 
 <h3>Initial Setup and Game Completion</h3>
 
@@ -190,9 +190,9 @@ other game items must be visible at all times. A captive is not required to
 give up a concealed item unless their captor asks for it specifically and knows
 that she has the item. Potions cannot be used while concealed. </li>
 
-<li>Dispelling: A dispelled item may not be used for its magical effects. Ussually items are dispelled for one minute. </li>
+<li>Dispelling: A dispelled item may not be used for its magical effects. Usually items are dispelled for one minute. </li>
 
-<li> Feild of Veiw: The field of view is the extent of the observable world that is visible to the player at any given moment. </li>
+<li> Field of View: The field of view is the extent of the observable world that is visible to the player at any given moment. </li>
 
 <li>Line of Sight: A player is within line of sight of an item or event if they can
 rotate themself to bring it into their field of view.</li>
@@ -242,7 +242,7 @@ gives up the item or drops the flag.<br>
 Judges wear blue headbands, and are responsible for keeping the game
 running smoothly. The head judge is the final arbiter and scorekeeper,
 and should remain in the judges' room, Wean Hall 8427. An assistant
-head judge shall reside at each team's jail, and there are ussually at
+head judge shall reside at each team's jail, and there are usually at
 least 2 roaming judges per team whose job is to resolve conflicts or
 perform other duties required of them.<br>
 Judges should attempt to resolve disputes fairly and find outcomes
@@ -294,7 +294,7 @@ to neutral space.<br>
 
 Potions are <font color="red">small pieces of foam wrapped in colored tape</font> which are concealable: you may hide them, and if
 captured, you do not need to give them up unless your captor knows you have
-them.  They are not useable while concealed. They are distinguished by color.<br>
+them.  They are not usable while concealed. They are distinguished by color.<br>
 
 <h3>Ninja Potion of Magic Smoke (Red, Sacrificial)</h3>
 The Ninja Potion of Magic Smoke is sacrificial, so may only be used in

--- a/rules/useful.txt
+++ b/rules/useful.txt
@@ -70,7 +70,7 @@ else
 	<br>
 	<i>Revised 8/10/2008, 12/2009 by edanaher</i>
 	<br>
-	<i>Revised 11/4/2015, by briedel, tparenti, zhg, jlareau, cmorey, eeb, egarbade, jpdoyle, mwoolfor, sctoor</i>
+	<i>Revised 11/4/2015, 2/8/2016, by briedel, tparenti, zhg, jlareau, cmorey, eeb, egarbade, jpdoyle, mwoolfor, sctoor</i>
 	<br>
 	<i>Classic rules may be found <a href="ctfws_old.php">here</a></i></center>
 

--- a/rules/useful.txt
+++ b/rules/useful.txt
@@ -380,11 +380,10 @@ To activate this belt, the captor hands it to a captive and says "I'LL BE BACH!!
 The captive sits down and becomes a captive of the belt for one minute;
 if another player dispels the belt, the captive goes free.
 Meanwhile, the captor has one minute to capture another player and return to original captive.
-Before they leave, the captor must start the timer attached to the belt (which will count out the minute).
 If the captor succeeds at acquiring another captive and returning to the original one, 
 the captor then escorts both of their captives to jail; 
 however, the belt can still be dispelled, freeing only the second captive.
-If the timer expires before the captor returns, the original captive goes free.
+If one minute elapses before the captor returns, the original captive goes free.
 <br>
 
 


### PR DESCRIPTION
This makes the following changes for Spring 2016:
- Removes physical timer from the new blue belt in all mentions.
- Clarifies how freed prisoners return to their home territory (_i.e.,_ as in jailbreaks, to be consistent with the existing text in the "useful" rules).
- Updates the dates for Spring 2016 and fixes several typos, especially in the "useful" rules.
