### PR TITLE
PHP: fix some tag soup issues

### DIFF
--- a/rules/generate.rb
+++ b/rules/generate.rb
@@ -302,10 +302,10 @@ end
 
 PHP_HEADER = <<EOH
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-<html><head>
 
-
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8"><title>Capture the Flag with Stuff</title>
+<?php
+$TEMPLATE_HEADERS=<<<HEAD
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 
 <link rel="stylesheet" type="text/css" href="basic.css">
 <style type="text/css">
@@ -339,9 +339,9 @@ span.change
 {
    color: red;
 }
-</style></head><body>
+</style>
+HEAD;
 
-<?php
 require("../web_kgb_2000/includes/lib.php");
 require("../web_kgb_2000/includes/template.php");
 require("../web_kgb_2000/includes/template_diet.php");
@@ -387,9 +387,6 @@ else
    template_pagebottom();
 
 ?>
-
-
-</body></html>
 EOH
 
 # Only used for testing; the PHP header is normally used.


### PR DESCRIPTION
Use the existing template's support for headers, don't nest HTML tags.